### PR TITLE
Фикс краша

### DIFF
--- a/src/samples/quad2d/quad2d_render.cpp
+++ b/src/samples/quad2d/quad2d_render.cpp
@@ -397,7 +397,7 @@ void Quad2D_Render::DrawFrameSimple()
   uint32_t imageIdx;
   m_swapchain.AcquireNextImage(m_presentationResources.imageAvailable, &imageIdx);
 
-  auto currentCmdBuf = m_cmdBuffersDrawMain[imageIdx];
+  auto currentCmdBuf = m_cmdBuffersDrawMain[m_presentationResources.currentFrame];
 
   VkSemaphore waitSemaphores[] = {m_presentationResources.imageAvailable};
   VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT};


### PR DESCRIPTION
Если размер свопчейна (например 5) отличался от количества ин-флайт фреймов (например 2), в строчке 400 вылетал segmentation fault из-за вылезания за границы массива. Патч фиксит это дело беря последовательно разные буферы на каждом кадре.