### PR TITLE
Фикс краша на мобильных ГПУ в семпле shadowmap

### DIFF
--- a/src/samples/shadowmap/shadowmap_render.cpp
+++ b/src/samples/shadowmap/shadowmap_render.cpp
@@ -157,7 +157,7 @@ void SimpleShadowmapRender::SetupSimplePipeline()
 {
   std::vector<std::pair<VkDescriptorType, uint32_t> > dtypes = {
       {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,             1},
-      {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,     1}
+      {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,     2}
   };
 
   m_pBindings = std::make_shared<vk_utils::DescriptorMaker>(m_device, dtypes, 2);


### PR DESCRIPTION
В размере пула дескриптор сетов нужно указывать количество __дескрипторов__, а не количество ресурсов, на которые они ссылаются. В данном семпле используется два разных дескриптора семплеров, а не один.
Если на дискретных ГПУ оно и так сожрёт, то на мобильных вылетает ассёрт с "unknown" ошибкой.