### PR TITLE
Сэмпл simple-forward больше не крашится при изменнии размера окна

### DIFF
--- a/src/render/render_gui.h
+++ b/src/render/render_gui.h
@@ -13,6 +13,7 @@ class IRenderGUI
 {
 public:
   virtual VkCommandBuffer BuildGUIRenderCommand(uint32_t a_swapchainFrameIdx, void* a_userData) = 0;
+  virtual void OnSwapchainChanged(const VulkanSwapChain &a_swapchain) = 0;
   virtual ~IRenderGUI() = default;
 };
 
@@ -24,7 +25,10 @@ class ImGuiRender : public IRenderGUI
 public:
   ImGuiRender(VkInstance a_instance, VkDevice a_device, VkPhysicalDevice a_physDevice, uint32_t a_queueFID, VkQueue a_queue,
     const VulkanSwapChain &a_swapchain);
+
   VkCommandBuffer BuildGUIRenderCommand(uint32_t a_swapchainFrameIdx, void* a_userData) override;
+  void OnSwapchainChanged(const VulkanSwapChain &a_swapchain) override;
+
   ~ImGuiRender() override;
 private:
   VkInstance m_instance = VK_NULL_HANDLE;
@@ -32,7 +36,7 @@ private:
   VkPhysicalDevice m_physDevice = VK_NULL_HANDLE;
   uint32_t m_queue_FID = UINT32_MAX;
   VkQueue m_queue = VK_NULL_HANDLE;
-  const VulkanSwapChain m_swapchain;
+  const VulkanSwapChain* m_swapchain;
 
   // Owned objects
   VkRenderPass m_renderpass = VK_NULL_HANDLE;

--- a/src/samples/simpleforward/simple_render.cpp
+++ b/src/samples/simpleforward/simple_render.cpp
@@ -337,6 +337,7 @@ void SimpleRender::RecreateSwapChain()
                              m_swapchain.GetAttachment(i).view, m_basicForwardPipeline.pipeline);
   }
 
+  m_pGUIRender->OnSwapchainChanged(m_swapchain);
 }
 
 void SimpleRender::Cleanup()
@@ -586,7 +587,16 @@ void SimpleRender::DrawFrameWithGUI()
   vkResetFences(m_device, 1, &m_frameFences[m_presentationResources.currentFrame]);
 
   uint32_t imageIdx;
-  m_swapchain.AcquireNextImage(m_presentationResources.imageAvailable, &imageIdx);
+  auto result = m_swapchain.AcquireNextImage(m_presentationResources.imageAvailable, &imageIdx);
+  if (result == VK_ERROR_OUT_OF_DATE_KHR)
+  {
+    RecreateSwapChain();
+    return;
+  }
+  else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR)
+  {
+    RUN_TIME_ERROR("Failed to acquire the next swapchain image!");
+  }
 
   auto currentCmdBuf = m_cmdBuffersDrawMain[m_presentationResources.currentFrame];
 


### PR DESCRIPTION
Фикс конечно костыльный, так как работает только если при пересоздании свопчейна изменился исключительно размер окна, но это хоть что-то.

P.S.
Использование константных полей в классах делает типы нерегулярными, а именно удаляют operator= копирования и мува, что может быть очень неожиданным для пользователей класса. "Хорошим стилем" считается делать типы попадающие в одну из следующих категорий: std::regular, std::semiregular, std::copyable, std::movable, "запиненные" (никак и никогда нельзя менять адрес объекта, ни копирований, ни мувов. Пример -- std::mutex).