### PR TITLE
Устранена утечка памяти при изменении размера окна

### DIFF
--- a/src/render/render_gui.h
+++ b/src/render/render_gui.h
@@ -30,6 +30,10 @@ public:
   void OnSwapchainChanged(const VulkanSwapChain &a_swapchain) override;
 
   ~ImGuiRender() override;
+
+private:
+  void ClearFrameBuffers();
+
 private:
   VkInstance m_instance = VK_NULL_HANDLE;
   VkDevice m_device = VK_NULL_HANDLE;

--- a/src/render/render_imgui.cpp
+++ b/src/render/render_imgui.cpp
@@ -114,11 +114,8 @@ void ImGuiRender::OnSwapchainChanged(const VulkanSwapChain &a_swapchain)
 {
   // If swapchain size changed, we are doomed, but that generaly does not happen. I think.
   m_swapchain = &a_swapchain;
-  if(!m_framebuffers.empty())
-  {
-    for(auto& fbuf: m_framebuffers)
-      vkDestroyFramebuffer(m_device, fbuf, VK_NULL_HANDLE);
-  }
+
+  ClearFrameBuffers();
   m_framebuffers = vk_utils::createFrameBuffers(m_device, *m_swapchain, m_renderpass);
 }
 
@@ -127,25 +124,37 @@ void ImGuiRender::CleanupImGui()
   ImGui_ImplVulkan_Shutdown();
   ImGui_ImplGlfw_Shutdown();
 
-  if(m_renderpass)
-    vkDestroyRenderPass(m_device, m_renderpass, VK_NULL_HANDLE);
+  ClearFrameBuffers();
 
-  if(!m_framebuffers.empty())
+  if(m_renderpass)
   {
-    for(auto& fbuf: m_framebuffers)
-      vkDestroyFramebuffer(m_device, fbuf, VK_NULL_HANDLE);
+    vkDestroyRenderPass(m_device, m_renderpass, VK_NULL_HANDLE);
+    m_renderpass = VK_NULL_HANDLE;
+  }
+  
+  if(m_commandPool)
+  {
+    vkDestroyCommandPool(m_device, m_commandPool, VK_NULL_HANDLE);
+    m_commandPool = VK_NULL_HANDLE;  
   }
 
-  if(m_commandPool)
-    vkDestroyCommandPool(m_device, m_commandPool, VK_NULL_HANDLE);
-
   if(m_descriptorPool)
+  {
     vkDestroyDescriptorPool(m_device, m_descriptorPool, VK_NULL_HANDLE);
+    m_descriptorPool = VK_NULL_HANDLE;   
+  }
 }
 
 ImGuiRender::~ImGuiRender()
 {
   CleanupImGui();
+}
+
+void ImGuiRender::ClearFrameBuffers()
+{
+  for(auto fbuf : m_framebuffers)
+    vkDestroyFramebuffer(m_device, fbuf, VK_NULL_HANDLE);
+  m_framebuffers.clear();
 }
 
 

--- a/src/samples/simpleforward/simple_render.cpp
+++ b/src/samples/simpleforward/simple_render.cpp
@@ -272,23 +272,23 @@ void SimpleRender::CleanupPipelineAndSwapchain()
 
   for (size_t i = 0; i < m_frameFences.size(); i++)
   {
-    if(m_frameFences[i] != VK_NULL_HANDLE)
-    {
-      vkDestroyFence(m_device, m_frameFences[i], nullptr);
-      m_frameFences[i] = VK_NULL_HANDLE;
-    }
+    vkDestroyFence(m_device, m_frameFences[i], nullptr);
   }
+  m_frameFences.clear();
 
   vk_utils::deleteImg(m_device, &m_depthBuffer);
+  
+  if(m_depthBuffer.mem != VK_NULL_HANDLE)
+  {
+    vkFreeMemory(m_device, m_depthBuffer.mem, nullptr);
+    m_depthBuffer.mem = VK_NULL_HANDLE;
+  }
 
   for (size_t i = 0; i < m_frameBuffers.size(); i++)
   {
-    if(m_frameBuffers[i] != VK_NULL_HANDLE)
-    {
-      vkDestroyFramebuffer(m_device, m_frameBuffers[i], nullptr);
-      m_frameBuffers[i] = VK_NULL_HANDLE;
-    }
+    vkDestroyFramebuffer(m_device, m_frameBuffers[i], nullptr);
   }
+  m_frameBuffers.clear();
 
   if(m_screenRenderPass != VK_NULL_HANDLE)
   {
@@ -389,14 +389,6 @@ void SimpleRender::Cleanup()
   {
     vkFreeMemory(m_device, m_uboAlloc, nullptr);
     m_uboAlloc = VK_NULL_HANDLE;
-  }
-
-//  vk_utils::deleteImg(m_device, &m_depthBuffer); // already deleted with swapchain
-
-  if(m_depthBuffer.mem != VK_NULL_HANDLE)
-  {
-    vkFreeMemory(m_device, m_depthBuffer.mem, nullptr);
-    m_depthBuffer.mem = VK_NULL_HANDLE;
   }
 
   m_pBindings = nullptr;


### PR DESCRIPTION
Depth buffer -- тоже как бы часть свопчейна, так как зависит от размеров окна, поэтому его очистка должна полностью происходить в функции CleanupPipelineAndSwapchain, в том числе и освобождение device memory, что я собственно и поменял. Остальные изменения -- мелкая чистка странного кода.