### PR TITLE
Use synchronization2 and fix barriers

### DIFF
--- a/src/samples/shadowmap/shadowmap_render.cpp
+++ b/src/samples/shadowmap/shadowmap_render.cpp
@@ -360,8 +360,9 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
         VkImageMemoryBarrier2
         {
           .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-          .srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-          .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+          // Our semo signals this stage
+          .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+          .srcAccessMask = 0,
           .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
           .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
           .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,


### PR DESCRIPTION
* Synchronization 2 does not require driver support, but simply provides a more convenient interface for applications
* Barriers were placed incorrectly, fixed them to be consistent with implicit subpass dependencies previously generated by our render passes