### PR TITLE
Fixed a bunch of stuff

### DIFF
--- a/resources/shaders/common.h
+++ b/resources/shaders/common.h
@@ -1,31 +1,54 @@
 #ifndef VK_GRAPHICS_BASIC_COMMON_H
 #define VK_GRAPHICS_BASIC_COMMON_H
 
-#ifdef __cplusplus
-#include <LiteMath.h>
-using LiteMath::uint2;
-using LiteMath::float2;
-using LiteMath::float3;
-using LiteMath::float4;
-using LiteMath::float4x4;
-using LiteMath::make_float2;
-using LiteMath::make_float4;
+// GLSL-C++ datatype compatibility layer
 
-typedef unsigned int uint;
-typedef uint2        uvec2;
-typedef float4       vec4;
-typedef float3       vec3;
-typedef float2       vec2;
-typedef float4x4     mat4;
+#ifdef __cplusplus
+
+#include <LiteMath.h>
+
+// NOTE: This is technically completely wrong,
+// as GLSL words are guaranteed to be 32-bit,
+// while C++ unsigned int can be 16-bit.
+// Touching LiteMath is forbidden though, so yeah.
+using shader_uint  = LiteMath::uint;
+using shader_uvec2 = LiteMath::uint2;
+using shader_uvec3 = LiteMath::uint3;
+
+using shader_float = float;
+using shader_vec2  = LiteMath::float2;
+using shader_vec3  = LiteMath::float3;
+using shader_vec4  = LiteMath::float4;
+using shader_mat4  = LiteMath::float4x4;
+
+// The funny thing is, on a GPU, you might as well consider
+// a single byte to be 32 bits, because nothing can be smaller
+// than 32 bits, so a bool has to be 32 bits as well.
+using shader_bool  = LiteMath::uint;
+
+#else
+
+#define shader_uint  uint
+#define shader_uvec2 uvec2
+
+#define shader_float float
+#define shader_vec2  vec2
+#define shader_vec3  vec3
+#define shader_vec4  vec4
+#define shader_mat4  mat4
+
+#define shader_bool  bool
+
 #endif
+
 
 struct UniformParams
 {
-  mat4  lightMatrix;
-  vec3  lightPos;
-  float time;
-  vec3  baseColor;
-  bool animateLightColor;
+  shader_mat4  lightMatrix;
+  shader_vec3  lightPos;
+  shader_float time;
+  shader_vec3  baseColor;
+  shader_bool  animateLightColor;
 };
 
-#endif //VK_GRAPHICS_BASIC_COMMON_H
+#endif // VK_GRAPHICS_BASIC_COMMON_H

--- a/resources/shaders/unpack_attributes.h
+++ b/resources/shaders/unpack_attributes.h
@@ -1,6 +1,7 @@
 #ifndef CHIMERA_UNPACK_ATTRIBUTES_H
 #define CHIMERA_UNPACK_ATTRIBUTES_H
 
+
 vec3 DecodeNormal(uint a_data)
 {
   const uint a_enc_x = (a_data  & 0x0000FFFFu);
@@ -20,6 +21,4 @@ vec3 DecodeNormal(uint a_data)
   return vec3(x, y, z);
 }
 
-
-
-#endif// CHIMERA_UNPACK_ATTRIBUTES_H
+#endif // CHIMERA_UNPACK_ATTRIBUTES_H

--- a/src/render/render_common.h
+++ b/src/render/render_common.h
@@ -10,9 +10,9 @@
 struct AppInput
 {
   AppInput(){
-    cams[1].pos    = float3(4.0f, 4.0f, 4.0f);
-    cams[1].lookAt = float3(0, 0, 0);
-    cams[1].up     = float3(0, 1, 0);
+    cams[1].pos    = LiteMath::float3(4.0f, 4.0f, 4.0f);
+    cams[1].lookAt = LiteMath::float3(0, 0, 0);
+    cams[1].up     = LiteMath::float3(0, 1, 0);
   }
 
   enum {MAXKEYS = 384};

--- a/src/samples/shadowmap/main.cpp
+++ b/src/samples/shadowmap/main.cpp
@@ -2,7 +2,7 @@
 #include "utils/glfw_window.h"
 #include <etna/Etna.hpp>
 
-void initVulkanGLFW(std::shared_ptr<IRender> &app, GLFWwindow* window, int deviceID)
+void initVulkanGLFW(std::shared_ptr<IRender> &app, GLFWwindow* window)
 {
   uint32_t glfwExtensionCount = 0;
   const char** glfwExtensions;
@@ -13,7 +13,7 @@ void initVulkanGLFW(std::shared_ptr<IRender> &app, GLFWwindow* window, int devic
     std::cout << "WARNING. Can't connect Vulkan to GLFW window (glfwGetRequiredInstanceExtensions returns NULL)" << std::endl;
   }
 
-  app->InitVulkan(glfwExtensions, glfwExtensionCount, deviceID);
+  app->InitVulkan(glfwExtensions, glfwExtensionCount, /* useless param */ 0);
 
   if(glfwExtensions != nullptr)
   {
@@ -28,7 +28,6 @@ int main()
 {
   constexpr int WIDTH = 1024;
   constexpr int HEIGHT = 1024;
-  constexpr int VULKAN_DEVICE_ID = 0;
 
   std::shared_ptr<IRender> app = std::make_unique<SimpleShadowmapRender>(WIDTH, HEIGHT);
   if(app == nullptr)
@@ -39,7 +38,7 @@ int main()
 
   auto* window = initWindow(WIDTH, HEIGHT);
 
-  initVulkanGLFW(app, window, VULKAN_DEVICE_ID);
+  initVulkanGLFW(app, window);
 
   app->LoadScene(VK_GRAPHICS_BASIC_ROOT "/resources/scenes/043_cornell_normals/statex_00001.xml", false);
 

--- a/src/samples/shadowmap/render_init.cpp
+++ b/src/samples/shadowmap/render_init.cpp
@@ -7,7 +7,7 @@ SimpleShadowmapRender::SimpleShadowmapRender(uint32_t a_width, uint32_t a_height
 {
 }
 
-void SimpleShadowmapRender::InitVulkan(const char** a_instanceExtensions, uint32_t a_instanceExtensionsCount, uint32_t a_deviceId)
+void SimpleShadowmapRender::InitVulkan(const char** a_instanceExtensions, uint32_t a_instanceExtensionsCount, uint32_t)
 {
   for(size_t i = 0; i < a_instanceExtensionsCount; ++i)
   {
@@ -26,6 +26,8 @@ void SimpleShadowmapRender::InitVulkan(const char** a_instanceExtensions, uint32
         {
           .features = m_enabledDeviceFeatures
         },
+      // Replace with an index if etna detects your preferred GPU incorrectly 
+      .physicalDeviceIndexOverride = {}
     });
   
   m_context = &etna::get_context();
@@ -43,7 +45,7 @@ void SimpleShadowmapRender::SetupDeviceExtensions()
 
 void SimpleShadowmapRender::RecreateSwapChain()
 {
-  m_context->getDevice().waitIdle();
+  ETNA_ASSERT(m_context->getDevice().waitIdle() == vk::Result::eSuccess);
 
   DeallocateResources();
 

--- a/src/samples/shadowmap/shadowmap_render.cpp
+++ b/src/samples/shadowmap/shadowmap_render.cpp
@@ -255,7 +255,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
         // Transfer the shadowmap to depth write layout
         VkImageMemoryBarrier2
         {
-          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
           .srcStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
           .srcAccessMask = VK_ACCESS_SHADER_READ_BIT,
           .dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
@@ -267,7 +267,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
           .image = m_pShadowMap2->m_attachments[0].image,
           .subresourceRange =
             {
-              .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+              .aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
               .baseMipLevel = 0,
               .levelCount = 1,
               .baseArrayLayer = 0,
@@ -338,7 +338,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
         // Transfer the shadowmap from depth write to shader read 
         VkImageMemoryBarrier2
         {
-          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
           .srcStageMask = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
           .srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
           .dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
@@ -350,7 +350,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
           .image = m_pShadowMap2->m_attachments[0].image,
           .subresourceRange =
             {
-              .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+              .aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
               .baseMipLevel = 0,
               .levelCount = 1,
               .baseArrayLayer = 0,
@@ -360,7 +360,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
         // Wait for the semaphore to signal that the swapchain image is available
         VkImageMemoryBarrier2
         {
-          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
           // Our semo signals this stage
           .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
           .srcAccessMask = 0,
@@ -472,7 +472,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
         // Transfer swapchain to present layout
         VkImageMemoryBarrier2
         {
-          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
           .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
           .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
           .dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,

--- a/src/samples/shadowmap/shadowmap_render.cpp
+++ b/src/samples/shadowmap/shadowmap_render.cpp
@@ -277,6 +277,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
       };
     VkDependencyInfo depInfo
       {
+        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
         .dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT,
         .imageMemoryBarrierCount = static_cast<uint32_t>(barriers.size()),
         .pImageMemoryBarriers = barriers.data(),
@@ -382,6 +383,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
       };
     VkDependencyInfo depInfo
       {
+        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
         .dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT,
         .imageMemoryBarrierCount = static_cast<uint32_t>(barriers.size()),
         .pImageMemoryBarriers = barriers.data(),
@@ -492,6 +494,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
       };
     VkDependencyInfo depInfo
       {
+        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
         .dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT,
         .imageMemoryBarrierCount = static_cast<uint32_t>(barriers.size()),
         .pImageMemoryBarriers = barriers.data(),

--- a/src/samples/shadowmap/shadowmap_render.h
+++ b/src/samples/shadowmap/shadowmap_render.h
@@ -24,8 +24,8 @@ public:
   SimpleShadowmapRender(uint32_t a_width, uint32_t a_height);
   ~SimpleShadowmapRender();
 
-  inline uint32_t     GetWidth()      const override { return m_width; }
-  inline uint32_t     GetHeight()     const override { return m_height; }
+  uint32_t     GetWidth()      const override { return m_width; }
+  uint32_t     GetHeight()     const override { return m_height; }
   VkInstance   GetVkInstance() const override { return m_context->getInstance(); }
 
   void InitVulkan(const char** a_instanceExtensions, uint32_t a_instanceExtensionsCount, uint32_t a_deviceId) override;

--- a/src/utils/Camera.h
+++ b/src/utils/Camera.h
@@ -2,31 +2,29 @@
 // Updated by Vadim Sanzharov, 2021
 #pragma once
 
-#include "LiteMath.h"
 
-using LiteMath::float3;
-using LiteMath::float4;
-using LiteMath::float4x4;
-using LiteMath::DEG_TO_RAD;
+#include "LiteMath.h"
 
 struct Camera
 {
   Camera() : pos(0.0f, 0.0f, +5.0f), lookAt(0, 0, 0), up(0, 1, 0), fov(45.0f), tdist(100.0f) {}
 
-  float3 pos;
-  float3 lookAt;
-  float3 up;
+  LiteMath::float3 pos;
+  LiteMath::float3 lookAt;
+  LiteMath::float3 up;
   float  fov;
   float  tdist;
 
-  float3 forward() const { return normalize(lookAt - pos); }
-  float3 right()   const { return cross(forward(), up); }
+  LiteMath::float3 forward() const { return normalize(lookAt - pos); }
+  LiteMath::float3 right()   const { return cross(forward(), up); }
 
   void offsetOrientation(float a_upAngle, float rightAngle)
   {
     if (a_upAngle != 0.0f)  // rotate vertical
     {
-      float3 direction = normalize(forward() * cosf(-DEG_TO_RAD*a_upAngle) + up * sinf(-DEG_TO_RAD*a_upAngle));
+      LiteMath::float3 direction = normalize(forward()
+        * cosf(-LiteMath::DEG_TO_RAD*a_upAngle) + up
+        * sinf(-LiteMath::DEG_TO_RAD*a_upAngle));
 
       up     = normalize(cross(right(), direction));
       lookAt = pos + tdist*direction;
@@ -34,19 +32,19 @@ struct Camera
 
     if (rightAngle != 0.0f)  // rotate horizontal
     {
-      float4x4 rot;
+      LiteMath::float4x4 rot;
 
-      rot[0][0] = rot[2][2] = cosf(DEG_TO_RAD * rightAngle);
-      rot[0][2] = -sinf(DEG_TO_RAD * rightAngle);
-      rot[2][0] = +sinf(DEG_TO_RAD * rightAngle);
+      rot[0][0] = rot[2][2] = cosf(LiteMath::DEG_TO_RAD * rightAngle);
+      rot[0][2] = -sinf(LiteMath::DEG_TO_RAD * rightAngle);
+      rot[2][0] = +sinf(LiteMath::DEG_TO_RAD * rightAngle);
 
-      float3 direction2 = LiteMath::normalize(mul(rot, forward()));
+      LiteMath::float3 direction2 = LiteMath::normalize(mul(rot, forward()));
       up     = normalize(mul(rot, up));
       lookAt = pos + tdist*direction2;
     }
   }
 
-  void offsetPosition(float3 a_offset)
+  void offsetPosition(LiteMath::float3 a_offset)
   {
     pos    += a_offset;
     lookAt += a_offset;
@@ -56,19 +54,19 @@ struct Camera
 
 // http://matthewwellings.com/blog/the-new-vulkan-coordinate-system/
 //
-static inline float4x4 OpenglToVulkanProjectionMatrixFix()
+static inline LiteMath::float4x4 OpenglToVulkanProjectionMatrixFix()
 {
-  float4x4 res;
+  LiteMath::float4x4 res;
   res[1][1] = -1.0f;
   res[2][2] = 0.5f;
   res[2][3] = 0.5f;
   return res;
 }
 
-static inline float4x4 projectionMatrix(float fovy, float aspect, float zNear, float zFar)
+static inline LiteMath::float4x4 projectionMatrix(float fovy, float aspect, float zNear, float zFar)
 {
-  float4x4 res;
-  const float ymax = zNear * tanf(fovy * DEG_TO_RAD * 0.5f);
+  LiteMath::float4x4 res;
+  const float ymax = zNear * tanf(fovy * LiteMath::DEG_TO_RAD * 0.5f);
   const float xmax = ymax * aspect;
 
   const float left   = -xmax;
@@ -104,7 +102,7 @@ static inline float4x4 projectionMatrix(float fovy, float aspect, float zNear, f
   return res;
 }
 
-static inline float4x4 perspectiveMatrix(float fovy, float aspect, float zNear, float zFar)
+static inline LiteMath::float4x4 perspectiveMatrix(float fovy, float aspect, float zNear, float zFar)
 {
   const float ymax = zNear * tanf(fovy * 3.14159265358979323846f / 360.0f);
   const float xmax = ymax * aspect;
@@ -116,17 +114,17 @@ static inline float4x4 perspectiveMatrix(float fovy, float aspect, float zNear, 
   const float temp2 = right - left;
   const float temp3 = top - bottom;
   const float temp4 = zFar - zNear;
-  float4x4 res;
-  res.set_col(0, float4{ temp / temp2, 0.0f, 0.0f, 0.0f });
-  res.set_col(1, float4{ 0.0f, temp / temp3, 0.0f, 0.0f });
-  res.set_col(2, float4{ (right + left) / temp2,  (top + bottom) / temp3, (-zFar - zNear) / temp4, -1.0 });
-  res.set_col(3, float4{ 0.0f, 0.0f, (-temp * zFar) / temp4, 0.0f });
+  LiteMath::float4x4 res;
+  res.set_col(0, LiteMath::float4{ temp / temp2, 0.0f, 0.0f, 0.0f });
+  res.set_col(1, LiteMath::float4{ 0.0f, temp / temp3, 0.0f, 0.0f });
+  res.set_col(2, LiteMath::float4{ (right + left) / temp2,  (top + bottom) / temp3, (-zFar - zNear) / temp4, -1.0 });
+  res.set_col(3, LiteMath::float4{ 0.0f, 0.0f, (-temp * zFar) / temp4, 0.0f });
   return res;
 }
 
-static inline float4x4 ortoMatrix(const float l, const float r, const float b, const float t, const float n, const float f)
+static inline LiteMath::float4x4 ortoMatrix(const float l, const float r, const float b, const float t, const float n, const float f)
 {
-  float4x4 res;
+  LiteMath::float4x4 res;
   res(0,0) = 2.0f / (r - l);
   res(0,1) = 0;
   res(0,2) = 0;
@@ -146,9 +144,9 @@ static inline float4x4 ortoMatrix(const float l, const float r, const float b, c
   return res;
 }
 
-static inline float4x4 ortoDumb()
+static inline LiteMath::float4x4 ortoDumb()
 {
-  float4x4 res;
+  LiteMath::float4x4 res;
   res(2,2) = 0;
 
   return res;


### PR DESCRIPTION
* Purged `using ...;` in global scope in headers
* Renamed types inside our GLSL-C++ bridge file with UBO struct -- defining stuff like `uint` leads to conflicts with other libraries, plus the purpose of such type is not clear. The intent is not for this type to be something general-purpose as `uint` implies, but specifically be THE uint that your GPU uses, therefore renamed it to `shader_uint`, as well as added `shader_` prefix to other such types and unified them. Also defined `shader_bool` as `uint32_t` in C++ -- it's 4 bytes wide in GLSL, not 1 as C++ `bool` is
* Fixed validation errors -- general dumb mistakes, somehow my validation layers were broken previously
* Removed `inline` from methods -- all methods in C++ are marked `inline` by the standard's mandate
* Added assertion for waiting on device -- discarded error code warning otherwise. As our assertion macro evaluate their argument even in release mode, the code is ok