### PR TITLE
Remade quad renderer class with etna

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ set(VK_UTILS_SRC
         ${CMAKE_SOURCE_DIR}/external/vkutils/vk_pipeline.cpp
         ${CMAKE_SOURCE_DIR}/external/vkutils/geom/vk_mesh.cpp
         ${CMAKE_SOURCE_DIR}/external/vkutils/geom/cmesh.cpp
-        ${CMAKE_SOURCE_DIR}/external/vkutils/vk_quad.cpp
         ${CMAKE_SOURCE_DIR}/external/vkutils/vk_fbuf_attachment.cpp)
 
 set(SCENE_LOADER_SRC

--- a/src/render/quad_renderer.cpp
+++ b/src/render/quad_renderer.cpp
@@ -1,0 +1,43 @@
+#include "quad_renderer.h"
+
+#include "etna/GlobalContext.hpp"
+#include "etna/Etna.hpp"
+#include "etna/RenderTargetStates.hpp"
+#include "etna/DescriptorSet.hpp"
+
+
+QuadRenderer::QuadRenderer(CreateInfo info) 
+{
+  m_rect      = info.rect;
+  m_programId = etna::create_program("quad_renderer", {
+    VK_GRAPHICS_BASIC_ROOT "/resources/shaders/quad3_vert.vert.spv",
+    VK_GRAPHICS_BASIC_ROOT "/resources/shaders/quad.frag.spv"
+  });
+
+  auto &pipelineManager = etna::get_context().getPipelineManager();
+  m_pipeline = pipelineManager.createGraphicsPipeline("quad_renderer",
+    {
+      .fragmentShaderOutput = 
+      {
+        .colorAttachmentFormats = {info.format}
+      }
+    });
+}
+
+void QuadRenderer::RecordCommands(vk::CommandBuffer cmdBuff, vk::Image targetImage, vk::ImageView targetImageView,
+                                  const etna::Image &inTex, const etna::Sampler &sampler)
+{
+  auto programInfo = etna::get_shader_program(m_programId);
+  auto set = etna::create_descriptor_set(programInfo.getDescriptorLayoutId(0), cmdBuff,
+    {
+      etna::Binding {0, inTex.genBinding(sampler.get(), vk::ImageLayout::eShaderReadOnlyOptimal)}
+    });
+  vk::DescriptorSet vkSet = set.getVkSet();
+
+  etna::RenderTargetState renderTargets(cmdBuff, m_rect, {{targetImage, targetImageView, false}}, {});
+
+  cmdBuff.bindPipeline(vk::PipelineBindPoint::eGraphics, m_pipeline.getVkPipeline());
+  cmdBuff.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, m_pipeline.getVkPipelineLayout(), 0, {vkSet}, {});
+
+  cmdBuff.draw(3, 1, 0, 0);
+}

--- a/src/render/quad_renderer.h
+++ b/src/render/quad_renderer.h
@@ -1,0 +1,36 @@
+#ifndef QUAD_RENDERER_H
+#define QUAD_RENDERER_H
+
+#include <vector>
+#include <string>
+#include <etna/Vulkan.hpp>
+#include "etna/GraphicsPipeline.hpp"
+#include "etna/Image.hpp"
+#include "etna/Sampler.hpp"
+
+
+class QuadRenderer
+{
+public:
+  struct CreateInfo
+  {
+    vk::Format format = vk::Format::eUndefined;
+    vk::Rect2D rect   = {};
+  };
+
+  QuadRenderer(CreateInfo info);
+  ~QuadRenderer() {}
+
+  void RecordCommands(vk::CommandBuffer cmdBuff, vk::Image targetImage, vk::ImageView targetImageView,
+                      const etna::Image &inTex, const etna::Sampler &sampler);
+
+private:
+  etna::GraphicsPipeline m_pipeline;
+  etna::ShaderProgramId m_programId;
+  vk::Rect2D m_rect {};
+
+  QuadRenderer(const QuadRenderer &) = delete;
+  QuadRenderer& operator=(const QuadRenderer &) = delete;
+};
+
+#endif // QUAD_RENDERER_H

--- a/src/samples/shadowmap/CMakeLists.txt
+++ b/src/samples/shadowmap/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 set(RENDER_SOURCE
         ../../render/scene_mgr.cpp
         ../../render/render_imgui.cpp
+        ../../render/quad_renderer.cpp
         shadowmap_render.cpp
         render_init.cpp
         update.cpp

--- a/src/samples/shadowmap/render_init.cpp
+++ b/src/samples/shadowmap/render_init.cpp
@@ -53,7 +53,6 @@ void SimpleShadowmapRender::RecreateSwapChain()
 
   DeallocateResources();
 
-  DestroyPipelines();
   ResetPresentStuff();
 
   auto oldImgNum = m_swapchain.GetImageCount();
@@ -71,6 +70,5 @@ void SimpleShadowmapRender::RecreateSwapChain()
 SimpleShadowmapRender::~SimpleShadowmapRender()
 {
   DeallocateResources();
-  DestroyPipelines();
   ResetPresentStuff();
 }

--- a/src/samples/shadowmap/shadowmap_render.cpp
+++ b/src/samples/shadowmap/shadowmap_render.cpp
@@ -79,18 +79,10 @@ void SimpleShadowmapRender::PreparePipelines()
 {
   // create full screen quad for debug purposes
   // 
-  m_pFSQuad = std::make_shared<vk_utils::QuadRenderer>(0,0, 512, 512);
-  m_pFSQuad->Create(m_context->getDevice(),
-    VK_GRAPHICS_BASIC_ROOT "/resources/shaders/quad3_vert.vert.spv",
-    VK_GRAPHICS_BASIC_ROOT "/resources/shaders/quad.frag.spv",
-    vk_utils::RenderTargetInfo2D{
-      .size          = VkExtent2D{ m_width, m_height },// this is debug full screen quad
-      .format        = m_swapchain.GetFormat(),
-      .loadOp        = VK_ATTACHMENT_LOAD_OP_LOAD,// seems we need LOAD_OP_LOAD if we want to draw quad to part of screen
-      .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-      .finalLayout   = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL 
-    }
-  );
+  m_pQuad = std::make_unique<QuadRenderer>(QuadRenderer::CreateInfo{ 
+      .format = static_cast<vk::Format>(m_swapchain.GetFormat()),
+      .rect = { 0, 0, 512, 512 }, 
+    });
   SetupSimplePipeline();
 }
 
@@ -103,17 +95,6 @@ void SimpleShadowmapRender::loadShaders()
 
 void SimpleShadowmapRender::SetupSimplePipeline()
 {
-  std::vector<std::pair<VkDescriptorType, uint32_t> > dtypes = {
-      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,             1},
-      {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,     2}
-  };
-
-  m_pBindings = std::make_shared<vk_utils::DescriptorMaker>(m_context->getDevice(), dtypes, 2);
-  
-  m_pBindings->BindBegin(VK_SHADER_STAGE_FRAGMENT_BIT);
-  m_pBindings->BindImage(0, shadowMap.getView({}), defaultSampler.get(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-  m_pBindings->BindEnd(&m_quadDS, &m_quadDSLayout);
-
   etna::VertexShaderInputDescription sceneVertexInputDesc
     {
       .bindings = {etna::VertexShaderInputDescription::Binding
@@ -141,12 +122,6 @@ void SimpleShadowmapRender::SetupSimplePipeline()
         }
     });
 }
-
-void SimpleShadowmapRender::DestroyPipelines()
-{
-  m_pFSQuad     = nullptr; // smartptr delete it's resources
-}
-
 
 
 /// COMMAND BUFFER FILLING
@@ -217,11 +192,7 @@ void SimpleShadowmapRender::BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, 
   }
 
   if(m_input.drawFSQuad)
-  {
-    float scaleAndOffset[4] = {0.5f, 0.5f, -0.5f, +0.5f};
-    m_pFSQuad->SetRenderTarget(a_targetImageView);
-    m_pFSQuad->DrawCmd(a_cmdBuff, m_quadDS, scaleAndOffset);
-  }
+    m_pQuad->RecordCommands(a_cmdBuff, a_targetImage, a_targetImageView, shadowMap, defaultSampler);
 
   etna::set_state(a_cmdBuff, a_targetImage, vk::PipelineStageFlagBits2::eBottomOfPipe,
     vk::AccessFlags2(), vk::ImageLayout::ePresentSrcKHR,

--- a/src/samples/shadowmap/shadowmap_render.h
+++ b/src/samples/shadowmap/shadowmap_render.h
@@ -3,6 +3,7 @@
 
 #include "../../render/scene_mgr.h"
 #include "../../render/render_common.h"
+#include "../../render/quad_renderer.h"
 #include "../../../resources/shaders/common.h"
 #include "etna/GraphicsPipeline.hpp"
 #include <geom/vk_mesh.h>
@@ -10,7 +11,6 @@
 #include <vk_fbuf_attachment.h>
 #include <vk_images.h>
 #include <vk_swapchain.h>
-#include <vk_quad.h>
 
 #include <string>
 #include <iostream>
@@ -77,8 +77,6 @@ private:
 
   etna::GraphicsPipeline m_basicForwardPipeline {};
   etna::GraphicsPipeline m_shadowPipeline {};
-
-  std::shared_ptr<vk_utils::DescriptorMaker> m_pBindings = nullptr;
   
   VkSurfaceKHR m_surface = VK_NULL_HANDLE;
   VulkanSwapChain m_swapchain;
@@ -93,12 +91,10 @@ private:
   std::vector<const char*> m_deviceExtensions;
   std::vector<const char*> m_instanceExtensions;
 
-  std::shared_ptr<SceneManager>     m_pScnMgr;
+  std::shared_ptr<SceneManager> m_pScnMgr;
   std::shared_ptr<IRenderGUI> m_pGUIRender;
   
-  std::shared_ptr<vk_utils::IQuad>               m_pFSQuad;
-  VkDescriptorSet       m_quadDS; 
-  VkDescriptorSetLayout m_quadDSLayout = nullptr;
+  std::unique_ptr<QuadRenderer> m_pQuad;
 
   struct InputControlMouseEtc
   {
@@ -130,9 +126,6 @@ private:
  
   void DrawFrameSimple(bool draw_gui);
 
-  void CreateInstance();
-  void CreateDevice(uint32_t a_deviceId);
-
   void BuildCommandBufferSimple(VkCommandBuffer a_cmdBuff, VkImage a_targetImage, VkImageView a_targetImageView);
 
   void DrawSceneCmd(VkCommandBuffer a_cmdBuff, const float4x4& a_wvp, VkPipelineLayout a_pipelineLayout = VK_NULL_HANDLE);
@@ -150,7 +143,6 @@ private:
   void AllocateResources();
   void PreparePipelines();
 
-  void DestroyPipelines();
   void DeallocateResources();
 
   void InitPresentStuff();


### PR DESCRIPTION
Remade the QuadRenderer class to etna from vk_utils, which allows us to draw any 2d texture to a part of the screen. I also reimplemented debug drawing of the lightmap in shadowmap_renderer to use this class.

This class uses the full power of etna's context, thus removing the need to keep track of it's descriptor sets, and allows for all draw commands to be issued in one method call. 

The usage of the class is as follows: construct it with the paths to v/f shaders and coordinates and dimensions of the part of the screen you will be drawing to (and come more required data for pipeline creation), and use RecordCommands to issue draw commands to a given command buffer.